### PR TITLE
fix: authenticate to Docker Hub before QEMU setup to avoid rate limits

### DIFF
--- a/.github/composite-actions/docker-build-push-ghcr/action.yml
+++ b/.github/composite-actions/docker-build-push-ghcr/action.yml
@@ -30,6 +30,14 @@ runs:
   using: "composite"
   steps:
     - uses: actions/checkout@v4
+
+    - name: Log in to Docker Hub (authenticated pulls)
+      if: env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != ''
+      uses: docker/login-action@v3
+      with:
+        username: ${{ env.DOCKERHUB_USERNAME }}
+        password: ${{ env.DOCKERHUB_TOKEN }}
+
     - uses: docker/setup-qemu-action@v3
     - uses: docker/setup-buildx-action@v3
     - uses: docker/login-action@v3

--- a/.github/composite-actions/docker-build-push-ghcr/action.yml
+++ b/.github/composite-actions/docker-build-push-ghcr/action.yml
@@ -32,11 +32,11 @@ runs:
     - uses: actions/checkout@v4
 
     - name: Log in to Docker Hub (authenticated pulls)
-      if: env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != ''
+      if: env.DOCKER_USERNAME != '' && env.DOCKER_TOKEN != ''
       uses: docker/login-action@v3
       with:
-        username: ${{ env.DOCKERHUB_USERNAME }}
-        password: ${{ env.DOCKERHUB_TOKEN }}
+        username: ${{ env.DOCKER_USERNAME }}
+        password: ${{ env.DOCKER_TOKEN }}
 
     - uses: docker/setup-qemu-action@v3
     - uses: docker/setup-buildx-action@v3

--- a/.github/workflows/docker-build-and-push-ghcr.yml
+++ b/.github/workflows/docker-build-and-push-ghcr.yml
@@ -4,10 +4,10 @@ on:
       GHCR_TOKEN:
         description: 'Token with packages:write. Optional; defaults to GITHUB_TOKEN.'
         required: false
-      DOCKERHUB_USERNAME:
+      DOCKER_USERNAME:
         description: 'Docker Hub username for authenticated pulls (avoids rate limits).'
         required: false
-      DOCKERHUB_TOKEN:
+      DOCKER_TOKEN:
         description: 'Docker Hub PAT or password for authenticated pulls.'
         required: false
     inputs:
@@ -63,5 +63,5 @@ jobs:
         env:
           GHCR_USERNAME: ${{ github.actor }}
           GHCR_TOKEN: ${{ secrets.GHCR_TOKEN || github.token }}
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}

--- a/.github/workflows/docker-build-and-push-ghcr.yml
+++ b/.github/workflows/docker-build-and-push-ghcr.yml
@@ -4,6 +4,12 @@ on:
       GHCR_TOKEN:
         description: 'Token with packages:write. Optional; defaults to GITHUB_TOKEN.'
         required: false
+      DOCKERHUB_USERNAME:
+        description: 'Docker Hub username for authenticated pulls (avoids rate limits).'
+        required: false
+      DOCKERHUB_TOKEN:
+        description: 'Docker Hub PAT or password for authenticated pulls.'
+        required: false
     inputs:
       docker-context:
         type: string
@@ -57,3 +63,5 @@ jobs:
         env:
           GHCR_USERNAME: ${{ github.actor }}
           GHCR_TOKEN: ${{ secrets.GHCR_TOKEN || github.token }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
## Problem

The `Distribute / Docker Build and Push (GHCR)` job fails on ARC runners with:

```
Error response from daemon: error from registry: You have reached your
unauthenticated pull rate limit.
```

This happens because `docker/setup-qemu-action@v3` pulls `docker.io/tonistiigi/binfmt:latest` **before** any registry login occurs. On shared-IP runner sets the anonymous Docker Hub rate limit is quickly exhausted.

Example failure: https://github.com/webgrip/infrastructure/actions/runs/26684531278/job/78650402964

## Fix

1. **Composite action** – adds a conditional `docker/login-action@v3` step for Docker Hub *before* the QEMU and buildx setup steps. The step is skipped when credentials are absent (fully backward compatible).

2. **Reusable workflow** – declares `DOCKER_USERNAME` and `DOCKER_TOKEN` as optional secrets and forwards them as env vars to the composite action.

## Required follow-up

After merging, add the following **organization secrets** (or repository secrets on each repo that calls this workflow):

| Secret | Value |
|--------|-------|
| `DOCKER_USERNAME` | Your Docker Hub username |
| `DOCKER_TOKEN` | A Docker Hub Personal Access Token (read-only is sufficient) |

Callers that already use `secrets: inherit` will pick these up automatically.